### PR TITLE
Close select dialog when autofocus is enabled

### DIFF
--- a/lib/src/selectDialog.dart
+++ b/lib/src/selectDialog.dart
@@ -305,28 +305,33 @@ class _SelectDialogState<T> extends State<SelectDialog<T>> {
 
   Widget _searchField() {
     return Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          widget.popupTitle ?? const SizedBox.shrink(),
-          if (widget.showSearchBox)
-            Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: TextField(
-                focusNode: focusNode,
-                onChanged: (f) => _debouncer(() {
-                  _onTextChanged(f);
-                }),
-                decoration: widget.searchBoxDecoration ??
-                    InputDecoration(
-                      hintText: widget.hintText,
-                      border: const OutlineInputBorder(),
-                      contentPadding:
-                          const EdgeInsets.symmetric(horizontal: 16),
-                    ),
-              ),
-            )
-        ]);
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        widget.popupTitle ?? const SizedBox.shrink(),
+        if (widget.showSearchBox)
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: TextField(
+              focusNode: focusNode,
+              onChanged: (f) => _debouncer(() {
+                _onTextChanged(f);
+              }),
+              onSubmitted: (value) {
+                if (widget.autoFocusSearchBox) {
+                  Navigator.of(context).pop();
+                }
+              },
+              decoration: widget.searchBoxDecoration ??
+                  InputDecoration(
+                    hintText: widget.hintText,
+                    border: const OutlineInputBorder(),
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+                  ),
+            ),
+          )
+      ],
+    );
   }
 }
 


### PR DESCRIPTION
If user enables keyboard autofocus, tapping Done on keyboard will close neither dialog or keyboard. Because dialog is not closed, keyboard is refocused again which results in weird glitching.

This PR makes Done button on keyboard close whole dialog without changing currently selected item . For cases when autofocus is off nothing changes.