### PR TITLE
After upgrading flutter to 1.24.0-10.2.pre 'shadowThemeOnly' property not available anymore

### DIFF
--- a/lib/src/popupMenu.dart
+++ b/lib/src/popupMenu.dart
@@ -608,7 +608,7 @@ Future<T> customShowMenu<T>({
       initialValue: initialValue,
       elevation: elevation,
       semanticLabel: label,
-      theme: Theme.of(context, shadowThemeOnly: true),
+      theme: Theme.of(context),
       popupMenuTheme: PopupMenuTheme.of(context),
       barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
       barrierColor: barrierColor,


### PR DESCRIPTION
After upgrading flutter to 1.24.0-10.2.pre 'shadowThemeOnly' property in Theme.of is not available anymore.
Fixed by removing this property