### PR TITLE
bottom sheet improvement

### DIFF
--- a/lib/dropdown_search.dart
+++ b/lib/dropdown_search.dart
@@ -346,14 +346,12 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
         shape: widget.popupShape,
         context: context,
         builder: (context) {
-          return SingleChildScrollView(
-            child: AnimatedPadding(
-              duration: Duration(milliseconds: 300),
-              padding: EdgeInsets.only(
-                bottom: MediaQuery.of(context).viewInsets.bottom,
-              ),
-              child: _selectDialogInstance(data, defaultHeight: 350),
+          return AnimatedPadding(
+            duration: Duration(milliseconds: 300),
+            padding: EdgeInsets.only(
+              bottom: MediaQuery.of(context).viewInsets.bottom,
             ),
+            child: _selectDialogInstance(data, defaultHeight: 350),
           );
         });
   }


### PR DESCRIPTION
This issue relates to the `bottom_sheet` mode.
Currently there is no reason to set `maxHeight` to any other value than default. Cause in case of long lists on small phones there will be no ability to scroll to the end of the list due to the overlapping keyboard.

Check the gif. There is items `1` and `2` that are not reachable in case of opened keyboard.
(the next gif will show the fix :-))

![Screen-Recording-2021-01-16-at-18 35 50](https://user-images.githubusercontent.com/6721286/104817509-60c00600-582a-11eb-931c-5c01e9371b5a.gif)

As far as the list of items represented with listview which supports scrolling the outer `SingleChildeScrollView` seems redundant. I removed it and now it works like it should. Check the gif.

![Screen-Recording-2021-01-16-at-18 45 15](https://user-images.githubusercontent.com/6721286/104817655-40447b80-582b-11eb-9dab-b13e49f08f26.gif)
