### PR TITLE
null safety bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.6.0] - 2021.03.27
+* fixed `null safety` issues after initial migraion
+* migrated example to `null safety`
+* allowed `http` traffic for Android to make async requests work
+
 ## [0.5.0] - 2021.03.23
 * Migrating to null-safety @thx [nizarhdt](https://github.com/nizarhdt)
 * add new feature: favorites items @thx [nizarhdt](https://github.com/nizarhdt)

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
          FlutterApplication and put your custom class here. -->
     <application
         android:label="example"
+        android:usesCleartextTraffic="true"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -52,30 +52,34 @@ class _MyHomePageState extends State<MyHomePage> {
                 popupItemDisabled: (String s) => s.startsWith('I'),
                 selectedItem: "Tunisia",
                 onBeforeChange: (a, b) {
-                  AlertDialog alert = AlertDialog(
-                    title: Text("Are you sure..."),
-                    content: Text("...you want to clear the selection"),
-                    actions: [
-                      FlatButton(
-                        child: Text("OK"),
-                        onPressed: () {
-                          Navigator.of(context).pop(true);
-                        },
-                      ),
-                      FlatButton(
-                        child: Text("NOT OK"),
-                        onPressed: () {
-                          Navigator.of(context).pop(false);
-                        },
-                      ),
-                    ],
-                  );
+                  if (b == null) {
+                    AlertDialog alert = AlertDialog(
+                      title: Text("Are you sure..."),
+                      content: Text("...you want to clear the selection"),
+                      actions: [
+                        TextButton(
+                          child: Text("OK"),
+                          onPressed: () {
+                            Navigator.of(context).pop(true);
+                          },
+                        ),
+                        TextButton(
+                          child: Text("NOT OK"),
+                          onPressed: () {
+                            Navigator.of(context).pop(false);
+                          },
+                        ),
+                      ],
+                    );
 
-                  return showDialog(
-                      context: context,
-                      builder: (BuildContext context) {
-                        return alert;
-                      });
+                    return showDialog<bool>(
+                        context: context,
+                        builder: (BuildContext context) {
+                          return alert;
+                        });
+                  }
+
+                  return Future.value(true);
                 },
               ),
               Divider(),
@@ -151,10 +155,9 @@ class _MyHomePageState extends State<MyHomePage> {
                   fillColor: Theme.of(context).inputDecorationTheme.fillColor,
                 ),
                 autoValidateMode: AutovalidateMode.onUserInteraction,
-                validator: (UserModel u) =>
-                    u == null ? "user field is required " : null,
+                validator: (u) => u == null ? "user field is required " : null,
                 onFind: (String filter) => getData(filter),
-                onChanged: (UserModel data) {
+                onChanged: (data) {
                   print(data);
                 },
                 dropdownBuilder: _customDropDownExample,
@@ -165,10 +168,10 @@ class _MyHomePageState extends State<MyHomePage> {
               ///custom itemBuilder and dropDownBuilder
               DropdownSearch<UserModel>(
                 showSelectedItem: true,
-                compareFn: (UserModel i, UserModel s) => i.isEqual(s),
+                compareFn: (i, s) => i.isEqual(s),
                 label: "Person",
                 onFind: (String filter) => getData(filter),
-                onChanged: (UserModel data) {
+                onChanged: (data) {
                   print(data);
                 },
                 dropdownBuilder: _customDropDownExample,
@@ -179,7 +182,15 @@ class _MyHomePageState extends State<MyHomePage> {
               ///BottomSheet Mode with no searchBox
               DropdownSearch<String>(
                 mode: Mode.BOTTOM_SHEET,
-                items: ["Brazil", "Italia", "Tunisia", 'Canada', 'Zraoua', 'France', 'Belgique'],
+                items: [
+                  "Brazil",
+                  "Italia",
+                  "Tunisia",
+                  'Canada',
+                  'Zraoua',
+                  'France',
+                  'Belgique'
+                ],
                 label: "Custom BottomShet mode",
                 onChanged: print,
                 selectedItem: "Brazil",
@@ -222,10 +233,10 @@ class _MyHomePageState extends State<MyHomePage> {
               DropdownSearch<UserModel>(
                 showSelectedItem: true,
                 showSearchBox: true,
-                compareFn: (UserModel i, UserModel s) => i.isEqual(s),
+                compareFn: (i, s) => i.isEqual(s),
                 label: "Person with favorite option",
-                onFind: (String filter) => getData(filter),
-                onChanged: (UserModel data) {
+                onFind: (filter) => getData(filter),
+                onChanged: (data) {
                   print(data);
                 },
                 dropdownBuilder: _customDropDownExample,
@@ -239,7 +250,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   return Container(
                     padding: EdgeInsets.symmetric(horizontal: 8, vertical: 6),
                     decoration: BoxDecoration(
-                        border: Border.all(color: Colors.grey[200]),
+                        border: Border.all(color: Colors.grey),
                         borderRadius: BorderRadius.circular(10),
                         color: Colors.grey[100]),
                     child: Text(
@@ -270,9 +281,9 @@ class _MyHomePageState extends State<MyHomePage> {
               DropdownSearch<String>(
                 items: ["no action", "confirm in the next dropdown"],
                 label: "open another dropdown programmatically",
-                onChanged: (String v) {
+                onChanged: (v) {
                   if (v == "confirm in the next dropdown") {
-                    _openDropDownProgKey.currentState.openDropDownSearch();
+                    _openDropDownProgKey.currentState?.openDropDownSearch();
                   }
                 },
               ),
@@ -283,34 +294,33 @@ class _MyHomePageState extends State<MyHomePage> {
                 label: "confirm",
                 showSelectedItem: true,
               ),
-              Row(
+              Column(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                mainAxisSize: MainAxisSize.max,
+                mainAxisSize: MainAxisSize.min,
                 children: [
-                  RaisedButton(
+                  ElevatedButton(
                       onPressed: () {
-                        _openDropDownProgKey.currentState.openDropDownSearch();
+                        _openDropDownProgKey.currentState?.openDropDownSearch();
                       },
-                      color: Theme.of(context).accentColor,
                       child: Text("Open dropdownSearch")),
-                  RaisedButton(
+                  ElevatedButton(
                       onPressed: () {
                         _openDropDownProgKey.currentState
-                            .changeSelectedItem("No");
+                            ?.changeSelectedItem("No");
                       },
                       child: Text("set to 'NO'")),
                   Material(
-                    child: RaisedButton(
+                    child: ElevatedButton(
                         onPressed: () {
                           _openDropDownProgKey.currentState
-                              .changeSelectedItem("Yes");
+                              ?.changeSelectedItem("Yes");
                         },
                         child: Text("set to 'YES'")),
                   ),
-                  RaisedButton(
+                  ElevatedButton(
                       onPressed: () {
                         _openDropDownProgKey.currentState
-                            .changeSelectedItem("Blabla");
+                            ?.changeSelectedItem("Blabla");
                       },
                       child: Text("set to 'Blabla'")),
                 ],
@@ -323,9 +333,13 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   Widget _customDropDownExample(
-      BuildContext context, UserModel item, String itemDesignation) {
+      BuildContext context, UserModel? item, String itemDesignation) {
+    if (item == null) {
+      return Container();
+    }
+
     return Container(
-      child: (item?.avatar == null)
+      child: (item.avatar == null)
           ? ListTile(
               contentPadding: EdgeInsets.all(0),
               leading: CircleAvatar(),
@@ -334,8 +348,9 @@ class _MyHomePageState extends State<MyHomePage> {
           : ListTile(
               contentPadding: EdgeInsets.all(0),
               leading: CircleAvatar(
-                backgroundImage: NetworkImage(item.avatar),
-              ),
+                  // this does not work - throws 404 error
+                  // backgroundImage: NetworkImage(item.avatar ?? ''),
+                  ),
               title: Text(item.name),
               subtitle: Text(
                 item.createdAt.toString(),
@@ -360,8 +375,9 @@ class _MyHomePageState extends State<MyHomePage> {
         title: Text(item.name),
         subtitle: Text(item.createdAt.toString()),
         leading: CircleAvatar(
-          backgroundImage: NetworkImage(item.avatar),
-        ),
+            // this does not work - throws 404 error
+            // backgroundImage: NetworkImage(item.avatar ?? ''),
+            ),
       ),
     );
   }
@@ -382,8 +398,9 @@ class _MyHomePageState extends State<MyHomePage> {
         title: Text(item.name),
         subtitle: Text(item.createdAt.toString()),
         leading: CircleAvatar(
-          backgroundImage: NetworkImage(item.avatar),
-        ),
+            // this does not work - throws 404 error
+            // backgroundImage: NetworkImage(item.avatar ?? ''),
+            ),
       ),
     );
   }
@@ -394,7 +411,11 @@ class _MyHomePageState extends State<MyHomePage> {
       queryParameters: {"filter": filter},
     );
 
-    var models = UserModel.fromJsonList(response.data);
-    return models;
+    final data = response.data;
+    if (data != null) {
+      return UserModel.fromJsonList(data);
+    }
+
+    return [];
   }
 }

--- a/example/lib/user_model.dart
+++ b/example/lib/user_model.dart
@@ -1,13 +1,13 @@
 class UserModel {
   final String id;
-  final DateTime createdAt;
+  final DateTime? createdAt;
   final String name;
-  final String avatar;
+  final String? avatar;
 
-  UserModel({this.id, this.createdAt, this.name, this.avatar});
+  UserModel(
+      {required this.id, this.createdAt, required this.name, this.avatar});
 
   factory UserModel.fromJson(Map<String, dynamic> json) {
-    if (json == null) return null;
     return UserModel(
       id: json["id"],
       createdAt:
@@ -18,7 +18,6 @@ class UserModel {
   }
 
   static List<UserModel> fromJsonList(List list) {
-    if (list == null) return null;
     return list.map((item) => UserModel.fromJson(item)).toList();
   }
 
@@ -28,13 +27,13 @@ class UserModel {
   }
 
   ///this method will prevent the override of toString
-  bool userFilterByCreationDate(String filter) {
-    return this?.createdAt?.toString()?.contains(filter);
+  bool? userFilterByCreationDate(String filter) {
+    return this.createdAt?.toString().contains(filter);
   }
 
   ///custom comparing function to check if two users are equal
-  bool isEqual(UserModel model) {
-    return this?.id == model?.id;
+  bool isEqual(UserModel? model) {
+    return this.id == model?.id;
   }
 
   @override

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -49,14 +49,14 @@ packages:
       name: dio
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.10"
+    version: "4.0.0-prev3"
   dropdown_search:
     dependency: "direct main"
     description:
-      name: dropdown_search
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.5.0"
+      path: ".."
+      relative: true
+    source: path
+    version: "0.6.0"
   fake_async:
     dependency: transitive
     description:
@@ -80,7 +80,7 @@ packages:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.4"
+    version: "4.0.0"
   matcher:
     dependency: transitive
     description:
@@ -113,7 +113,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,14 +12,15 @@ description: A new Flutter project.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 version: 1.0.0+1
+publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  dio: ^3.0.1
+  dio: ^4.0.0-prev3
   dropdown_search:
-    # path: ../
+     path: ../
   flutter:
     sdk: flutter
 

--- a/lib/dropdown_search.dart
+++ b/lib/dropdown_search.dart
@@ -12,9 +12,9 @@ import 'src/selectDialog.dart';
 typedef Future<List<T>> DropdownSearchOnFind<T>(String text);
 typedef String DropdownSearchItemAsString<T>(T item);
 typedef bool DropdownSearchFilterFn<T>(T item, String filter);
-typedef bool DropdownSearchCompareFn<T>(T item, T selectedItem);
+typedef bool DropdownSearchCompareFn<T>(T item, T? selectedItem);
 typedef Widget DropdownSearchBuilder<T>(
-    BuildContext context, T selectedItem, String itemAsString);
+    BuildContext context, T? selectedItem, String itemAsString);
 typedef Widget DropdownSearchPopupItemBuilder<T>(
   BuildContext context,
   T item,
@@ -26,7 +26,7 @@ typedef Widget ErrorBuilder<T>(
 typedef Widget EmptyBuilder<T>(BuildContext context, String? searchEntry);
 typedef Widget LoadingBuilder<T>(BuildContext context, String? searchEntry);
 typedef Widget IconButtonBuilder(BuildContext context);
-typedef Future<bool> BeforeChange<T>(T prevItem, T nextItem);
+typedef Future<bool?> BeforeChange<T>(T prevItem, T nextItem);
 
 typedef Widget FavoriteItemsBuilder<T>(BuildContext context, T item);
 
@@ -61,7 +61,7 @@ class DropdownSearch<T> extends StatefulWidget {
   final DropdownSearchOnFind<T>? onFind;
 
   ///called when a new item is selected
-  final ValueChanged<T>? onChanged;
+  final ValueChanged<T?>? onChanged;
 
   ///to customize list of items UI
   final DropdownSearchBuilder<T>? dropdownBuilder;
@@ -170,7 +170,7 @@ class DropdownSearch<T> extends StatefulWidget {
   final Duration? searchDelay;
 
   /// callback executed before applying value change
-  final BeforeChange<T>? onBeforeChange;
+  final BeforeChange<T?>? onBeforeChange;
 
   ///show or hide favorites items
   final bool showFavoriteItems;
@@ -241,7 +241,7 @@ class DropdownSearch<T> extends StatefulWidget {
   DropdownSearchState<T> createState() => DropdownSearchState<T>();
 }
 
-class DropdownSearchState<T> extends State<DropdownSearch<T?>> {
+class DropdownSearchState<T> extends State<DropdownSearch<T>> {
   final ValueNotifier<T?> _selectedItemNotifier = ValueNotifier(null);
   final ValueNotifier<bool> _isFocused = ValueNotifier(false);
 
@@ -252,7 +252,7 @@ class DropdownSearchState<T> extends State<DropdownSearch<T?>> {
   }
 
   @override
-  void didUpdateWidget(DropdownSearch<T?> oldWidget) {
+  void didUpdateWidget(DropdownSearch<T> oldWidget) {
     final oldSelectedItem = oldWidget.selectedItem;
     final newSelectedItem = widget.selectedItem;
     if (oldSelectedItem != newSelectedItem) {
@@ -265,7 +265,7 @@ class DropdownSearchState<T> extends State<DropdownSearch<T?>> {
   Widget build(BuildContext context) {
     return ValueListenableBuilder<T?>(
       valueListenable: _selectedItemNotifier,
-      builder: (context, T? data, wt) {
+      builder: (context, data, wt) {
         return IgnorePointer(
           ignoring: !widget.enabled,
           child: GestureDetector(
@@ -309,9 +309,9 @@ class DropdownSearchState<T> extends State<DropdownSearch<T?>> {
             state.didChange(value);
           });
         }
-        return ValueListenableBuilder(
+        return ValueListenableBuilder<bool>(
             valueListenable: _isFocused,
-            builder: (context, bool isFocused, w) {
+            builder: (context, isFocused, w) {
               return InputDecorator(
                 isEmpty: value == null &&
                     (widget.dropdownBuilder == null ||
@@ -454,8 +454,8 @@ class DropdownSearchState<T> extends State<DropdownSearch<T?>> {
         ]);
   }
 
-  SelectDialog<T?> _selectDialogInstance(T? data, {double? defaultHeight}) {
-    return SelectDialog<T?>(
+  SelectDialog<T> _selectDialogInstance(T? data, {double? defaultHeight}) {
+    return SelectDialog<T>(
       searchBoxStyle: widget.searchBoxStyle,
       popupTitle: widget.popupTitle,
       maxHeight: widget.maxHeight ?? defaultHeight,

--- a/lib/src/popupMenu.dart
+++ b/lib/src/popupMenu.dart
@@ -433,7 +433,7 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
   final RelativeRect? position;
   final List<PopupMenuEntry<T>> items;
   final List<Size?> itemSizes;
-  final dynamic initialValue;
+  final T? initialValue;
   final double? elevation;
   final ThemeData? theme;
   final String? semanticLabel;

--- a/lib/src/selectDialog.dart
+++ b/lib/src/selectDialog.dart
@@ -90,12 +90,12 @@ class SelectDialog<T> extends StatefulWidget {
   _SelectDialogState<T> createState() => _SelectDialogState<T>();
 }
 
-class _SelectDialogState<T> extends State<SelectDialog<T?>> {
+class _SelectDialogState<T> extends State<SelectDialog<T>> {
   final FocusNode focusNode = new FocusNode();
-  final StreamController<List<T?>> _itemsStream =
-      StreamController<List<T?>>.broadcast();
+  final StreamController<List<T>> _itemsStream =
+      StreamController<List<T>>.broadcast();
   final ValueNotifier<bool> _loadingNotifier = ValueNotifier(false);
-  final List<T?> _items = <T>[];
+  final List<T> _items = <T>[];
   late Debouncer _debouncer;
 
   @override
@@ -142,7 +142,7 @@ class _SelectDialogState<T> extends State<SelectDialog<T?>> {
           Expanded(
             child: Stack(
               children: <Widget>[
-                StreamBuilder<List<T?>>(
+                StreamBuilder<List<T>>(
                   stream: _itemsStream.stream,
                   builder: (context, snapshot) {
                     if (snapshot.hasError) {
@@ -179,7 +179,7 @@ class _SelectDialogState<T> extends State<SelectDialog<T?>> {
   }
 
   void _showErrorDialog(dynamic error) {
-    showDialog(
+    showDialog<void>(
       context: context,
       barrierDismissible: false,
       builder: (BuildContext context) {
@@ -242,7 +242,7 @@ class _SelectDialogState<T> extends State<SelectDialog<T?>> {
   void manageItemsByFilter(String filter, {bool isFistLoad = false}) async {
     _loadingNotifier.value = true;
 
-    List<T?> applyFilter(String filter) {
+    List<T> applyFilter(String filter) {
       return _items.where((i) {
         if (widget.filterFn != null)
           return (widget.filterFn!(i, filter));
@@ -263,7 +263,7 @@ class _SelectDialogState<T> extends State<SelectDialog<T?>> {
     //manage offline items
     if (widget.onFind != null && (widget.isFilteredOnline || isFistLoad)) {
       try {
-        final List<T?> onlineItems = [];
+        final List<T> onlineItems = [];
         onlineItems.addAll(await widget.onFind!(filter));
 
         //Remove all old data
@@ -302,7 +302,7 @@ class _SelectDialogState<T> extends State<SelectDialog<T?>> {
     _loadingNotifier.value = false;
   }
 
-  void _addDataToStream(List<T?> data) {
+  void _addDataToStream(List<T> data) {
     if (_itemsStream.isClosed) return;
     _itemsStream.add(data);
   }
@@ -312,7 +312,7 @@ class _SelectDialogState<T> extends State<SelectDialog<T?>> {
     _itemsStream.addError(error, stackTrace);
   }
 
-  Widget _itemWidget(T? item) {
+  Widget _itemWidget(T item) {
     if (widget.itemBuilder != null)
       return InkWell(
         child: widget.itemBuilder!(
@@ -377,7 +377,7 @@ class _SelectDialogState<T> extends State<SelectDialog<T?>> {
   }
 
   Widget _favoriteItemsWidget() {
-    return StreamBuilder<List<T?>>(
+    return StreamBuilder<List<T>>(
         stream: _itemsStream.stream,
         builder: (context, snapshot) {
           if (snapshot.hasData) {
@@ -388,7 +388,7 @@ class _SelectDialogState<T> extends State<SelectDialog<T?>> {
         });
   }
 
-  Widget _buildFavoriteItems(List<T?>? favoriteItems) {
+  Widget _buildFavoriteItems(List<T>? favoriteItems) {
     if (favoriteItems != null) {
       return Container(
         padding: EdgeInsets.symmetric(horizontal: 8),
@@ -423,7 +423,7 @@ class _SelectDialogState<T> extends State<SelectDialog<T?>> {
     }
   }
 
-  void _handleSelectItem(T? selectedItem) {
+  void _handleSelectItem(T selectedItem) {
     Navigator.pop(context, selectedItem);
     if (widget.onChanged != null) widget.onChanged!(selectedItem);
   }
@@ -460,7 +460,7 @@ class Debouncer {
 
   Debouncer({this.delay});
 
-  call(Function action) {
+  void call(Function action) {
     _timer?.cancel();
     _timer = Timer(
         delay ?? const Duration(milliseconds: 500), action as void Function());

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dropdown_search
 description: Simple and robust Searchable Dropdown with item search feature, making it possible to use an offline item list or filtering URL for easy customization.
-version: 0.5.0
+version: 0.6.0
 homepage: https://github.com/salim-lachdhaf
 git: https://github.com/salim-lachdhaf/searchable_dropdown
 repository: https://github.com/salim-lachdhaf/searchable_dropdown


### PR DESCRIPTION
Hi @salim-lachdhaf 
I added some fixes to the null safety.

After initial migration the package was barely usable due to runtime errors.

```
[ERROR:flutter/lib/ui/ui_dart_state.cc(186)] Unhandled Exception: type '(String) => bool' is not a subtype of type '((String?) => bool)?'
```

I noticed this errors while migrating my package to null safety.

I also migrated `example` to null safety and made it runnable.
Allowed `http` traffic for Android to make requests work while running `example` on emulator

I prepared CHANGELOG and bumped pubspec version.
I hope you'll merge and release new version soon