### PR TITLE
Added property to customize DropdownButton Splash Radius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.6.3] - 2021.06.02
+* added property to set up the splash radius in dropdown_search
+
 ## [0.6.2] - 2021.05.22
 * prop that passes all props to search field
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [0.6.3] - 2021.06.02
-* added property to set up the splash radius in dropdown_search
+* added property to set up the splash radius for clear button and for dropdown button in dropdown_search
 
 ## [0.6.2] - 2021.05.22
 * prop that passes all props to search field

--- a/README.md
+++ b/README.md
@@ -178,8 +178,9 @@ You can customize the layout of the DropdownSearch and its items. [EXAMPLE](http
 |`onSaved`|An optional method to call with the final value when the form is saved via|
 |`validator`|An optional method that validates an input. Returns an error string to display if the input is invalid, or null otherwise.|
 |`clearButton`|customize clear button widget|
+|`clearButtonSplashRadius`|customize clear button splash radius|
 |`dropDownButton`|customize dropdown button widget|
-|`dropDownButtonSplashRadius`|customize dropdown splash radius|
+|`dropDownButtonSplashRadius`|customize dropdown button splash radius|
 |`dropdownBuilderSupportsNullItem`|If true, the dropdownBuilder will continue the uses of material behavior. This will be useful if you want to handle a custom UI only if the item !=null|
 |`popupItemDisabled`|defines if an item of the popup is enabled or not, if the item is disabled, it cannot be clicked|
 |`popupBarrierColor`|set a custom color for the popup barrier|

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ You can customize the layout of the DropdownSearch and its items. [EXAMPLE](http
 |`validator`|An optional method that validates an input. Returns an error string to display if the input is invalid, or null otherwise.|
 |`clearButton`|customize clear button widget|
 |`dropDownButton`|customize dropdown button widget|
+|`dropDownButtonSplashRadius`|customize dropdown splash radius|
 |`dropdownBuilderSupportsNullItem`|If true, the dropdownBuilder will continue the uses of material behavior. This will be useful if you want to handle a custom UI only if the item !=null|
 |`popupItemDisabled`|defines if an item of the popup is enabled or not, if the item is disabled, it cannot be clicked|
 |`popupBarrierColor`|set a custom color for the popup barrier|
@@ -190,7 +191,7 @@ You can customize the layout of the DropdownSearch and its items. [EXAMPLE](http
 |`popupSafeArea`|set properties of popup safe area|
 
 # Attention
-To use a template as an item type, and you don't want to use a custom fonction **itemAsString** and **compareFn** you **need** to implement **toString**, **equals** and **hashcode**, as shown below:
+To use a template as an item type, and you don't want to use a custom function **itemAsString** and **compareFn** you **need** to implement **toString**, **equals** and **hashcode**, as shown below:
 
 
 ```dart

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -125,6 +125,7 @@ class _MyHomePageState extends State<MyHomePage> {
                       ],
                       label: "Menu mode *",
                       showClearButton: true,
+                      clearButtonSplashRadius: 20,
                       onChanged: print,
                       popupItemDisabled: (String s) => s.startsWith('I'),
                       selectedItem: "Tunisia",

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -299,6 +299,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 items: ["Yes", "No"],
                 label: "confirm",
                 showSelectedItem: true,
+                dropdownButtonSplashRadius: 20,
               ),
               Column(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -126,7 +126,6 @@ class _MyHomePageState extends State<MyHomePage> {
                       ],
                       label: "Menu mode *",
                       showClearButton: true,
-                      clearButtonSplashRadius: 20,
                       onChanged: print,
                       popupItemDisabled: (String s) => s.startsWith('I'),
                       selectedItem: "Tunisia",

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -50,6 +50,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 showClearButton: true,
                 onChanged: print,
                 popupItemDisabled: (String s) => s.startsWith('I'),
+                clearButtonSplashRadius: 20,
                 selectedItem: "Tunisia",
                 onBeforeChange: (a, b) {
                   if (b == null) {

--- a/lib/dropdown_search.dart
+++ b/lib/dropdown_search.dart
@@ -152,6 +152,10 @@ class DropdownSearch<T> extends StatefulWidget {
   ///custom dropdown button widget builder
   final IconButtonBuilder? dropdownButtonBuilder;
 
+  ///custom splash radius for the dropdown button
+  ///If null, default splash radius of [icon_button] is used.
+  final double? dropdownButtonSplashRadius;
+
   ///whether to manage the clear and dropdown icons via InputDecoration suffixIcon
   final bool showAsSuffixIcons;
 
@@ -235,6 +239,7 @@ class DropdownSearch<T> extends StatefulWidget {
     this.clearButtonBuilder,
     this.dropDownButton,
     this.dropdownButtonBuilder,
+    this.dropdownButtonSplashRadius,
     this.showAsSuffixIcons = false,
     this.dropdownBuilderSupportsNullItem = false,
     this.popupShape,
@@ -387,6 +392,7 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
               : IconButton(
                   icon: widget.clearButton ?? const Icon(Icons.clear, size: 24),
                   onPressed: clearButtonPressed,
+                  splashRadius: widget.dropdownButtonSplashRadius ?? null,
                 ),
         widget.dropdownButtonBuilder != null
             ? GestureDetector(
@@ -397,6 +403,7 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
                 icon: widget.dropDownButton ??
                     const Icon(Icons.arrow_drop_down, size: 24),
                 onPressed: dropdownButtonPressed,
+                splashRadius: widget.dropdownButtonSplashRadius ?? null,
               ),
       ],
     );

--- a/lib/dropdown_search.dart
+++ b/lib/dropdown_search.dart
@@ -142,6 +142,10 @@ class DropdownSearch<T> extends StatefulWidget {
   ///custom clear button widget builder
   final IconButtonBuilder? clearButtonBuilder;
 
+  ///custom splash radius for the clear button
+  ///If null, default splash radius of [icon_button] is used.
+  final double? clearButtonSplashRadius;
+
   ///custom dropdown icon button widget
   final Widget? dropDownButton;
 
@@ -237,6 +241,7 @@ class DropdownSearch<T> extends StatefulWidget {
     this.dialogMaxWidth,
     this.clearButton,
     this.clearButtonBuilder,
+    this.clearButtonSplashRadius,
     this.dropDownButton,
     this.dropdownButtonBuilder,
     this.dropdownButtonSplashRadius,
@@ -392,7 +397,7 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
               : IconButton(
                   icon: widget.clearButton ?? const Icon(Icons.clear, size: 24),
                   onPressed: clearButtonPressed,
-                  splashRadius: widget.dropdownButtonSplashRadius ?? null,
+                  splashRadius: widget.clearButtonSplashRadius ?? null,
                 ),
         widget.dropdownButtonBuilder != null
             ? GestureDetector(


### PR DESCRIPTION
Add possibility to customize the Splash Radius of the Dropdown Button and the Clear Button.

By adding this feature, you can make the radius splash the size you like so it can fit inside the container.

## Dropdown Button
|  Default Size |   Custom Size (20)|
| ------------ | ------------ |
|![image](https://user-images.githubusercontent.com/35068259/120570035-8fabd280-c3ed-11eb-9e13-7b13b96b8a46.png)|![image](https://user-images.githubusercontent.com/35068259/120570056-9d615800-c3ed-11eb-975f-8e7389dc1db0.png)|


## Clear Button
|  Default Size |   Custom Size (20)|
| ------------ | ------------ |
|![image](https://user-images.githubusercontent.com/35068259/120571632-ef57ad00-c3f0-11eb-8566-827ffa504062.png)|![image](https://user-images.githubusercontent.com/35068259/120571560-c0d9d200-c3f0-11eb-90e1-058b4dbc9a73.png)|