### PR TITLE
more gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ pubspec.lock
 
 # Flutter/Dart/Pub related
 **/doc/api/
+**/ios/.symlinks
+.fvm
 .dart_tool/
 .flutter-plugins
 .packages


### PR DESCRIPTION
This PR adds two gitignore items

`.fvm` to ignore the flutter version manager folder
`ios/.symlinks` to ignore corresponding folder from `example`

Without this two ignores `pub publish` will fail due to the bundle size limit