### PR TITLE
ignore pointers in itemBuilder & cursor in web

### DIFF
--- a/lib/dropdown_search.dart
+++ b/lib/dropdown_search.dart
@@ -295,7 +295,7 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
       builder: (context, data, wt) {
         return IgnorePointer(
           ignoring: !widget.enabled,
-          child: GestureDetector(
+          child: InkWell(
             onTap: () => _selectSearchMode(data),
             child: _formField(data),
           ),
@@ -390,7 +390,7 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
       children: <Widget>[
         if (data != null && widget.showClearButton == true)
           widget.clearButtonBuilder != null
-              ? GestureDetector(
+              ? InkWell(
                   onTap: clearButtonPressed,
                   child: widget.clearButtonBuilder!(context),
                 )
@@ -399,7 +399,7 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
                   onPressed: clearButtonPressed,
                 ),
         widget.dropdownButtonBuilder != null
-            ? GestureDetector(
+            ? InkWell(
                 onTap: dropdownButtonPressed,
                 child: widget.dropdownButtonBuilder!(context),
               )

--- a/lib/src/selectDialog.dart
+++ b/lib/src/selectDialog.dart
@@ -356,10 +356,14 @@ class _SelectDialogState<T> extends State<SelectDialog<T>> {
   Widget _itemWidget(T item) {
     if (widget.itemBuilder != null)
       return InkWell(
-        child: widget.itemBuilder!(
-          context,
-          item,
-          _manageSelectedItemVisibility(item),
+        // ignore pointers in itemBuilder
+        child: IgnorePointer(
+          ignoring: true,
+          child: widget.itemBuilder!(
+            context,
+            item,
+            _manageSelectedItemVisibility(item),
+          ),
         ),
         onTap:
             widget.itemDisabled != null && (widget.itemDisabled!(item)) == true
@@ -502,7 +506,7 @@ class _SelectDialogState<T> extends State<SelectDialog<T>> {
                       widget.favoriteItemsAlignment ?? MainAxisAlignment.start,
                   children: favoriteItems
                       .map(
-                        (f) => GestureDetector(
+                        (f) => InkWell(
                           onTap: () => _handleSelectItem(f),
                           child: Container(
                             margin: EdgeInsets.only(right: 4),


### PR DESCRIPTION
Display the clicked cursor on web versions.

Ignore pointers that are set in itemBuilder by the user.
Therefore, the user will not be able to make a hotspot in itemBuilder.