### PR TITLE
🐛 sudden appearance of input's error text shifts the entire content downwards

### DIFF
--- a/lib/dropdown_search.dart
+++ b/lib/dropdown_search.dart
@@ -361,16 +361,31 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
         return ValueListenableBuilder<bool>(
             valueListenable: _isFocused,
             builder: (context, isFocused, w) {
-              return InputDecorator(
-                baseStyle: widget.dropdownSearchBaseStyle,
-                textAlign: widget.dropdownSearchTextAlign,
-                textAlignVertical: widget.dropdownSearchTextAlignVertical,
-                isEmpty: value == null &&
-                    (widget.dropdownBuilder == null ||
-                        widget.dropdownBuilderSupportsNullItem),
-                isFocused: isFocused,
-                decoration: _manageDropdownDecoration(state, value),
-                child: _defaultSelectItemWidget(value),
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  InputDecorator(
+                    baseStyle: widget.dropdownSearchBaseStyle,
+                    textAlign: widget.dropdownSearchTextAlign,
+                    textAlignVertical: widget.dropdownSearchTextAlignVertical,
+                    isEmpty: value == null &&
+                        (widget.dropdownBuilder == null ||
+                            widget.dropdownBuilderSupportsNullItem),
+                    isFocused: isFocused,
+                    decoration: _manageDropdownDecoration(state, value),
+                    child: _defaultSelectItemWidget(value),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8, left: 16),
+                    child: Text(
+                      state.errorText ?? '',
+                      style: Theme.of(context)
+                          .textTheme
+                          .caption!
+                          .copyWith(color: Theme.of(context).errorColor),
+                    ),
+                  ),
+                ],
               );
             });
       },
@@ -389,8 +404,7 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
             labelText: widget.label,
             hintText: widget.hint,
             suffixIcon:
-                widget.showAsSuffixIcons ? _manageTrailingIcons(data) : null,
-            errorText: state.errorText);
+                widget.showAsSuffixIcons ? _manageTrailingIcons(data) : null);
   }
 
   ///function that return the String value of an object


### PR DESCRIPTION
According to the [Material Design spec about text fields](https://material.io/components/text-fields#anatomy):

>  Swapping helper text with error text helps prevent new lines of text from being introduced into a layout, thus bumping content to fit it.

The guildelines strongly recommend against shifting layout content when the input's error text appears. In my fix, the helper text is an empty string `''` by default.

By the way, your package is awesome and superb, thank you so so much for developing it. Please merge my PR quickly so that I can use it in my final university project.

**Before my commit, the entire layout is shifted downwards when the error text of FormField appears:** 
![Before](https://user-images.githubusercontent.com/29955043/121890509-a2ef6400-cd44-11eb-91bb-6f0b4a764b5e.gif)

**After my commit, the entire layout is unchanged (which follows the Material Design spec)** 
![After](https://user-images.githubusercontent.com/29955043/121890530-a71b8180-cd44-11eb-8d75-4e2eddc15213.gif)