### PR TITLE
Added an optional divider widget between multiselect popup buttons an…

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -124,6 +124,9 @@ class _MyHomePageState extends State<MyHomePage> {
                     ],
                   );
                 },
+                popupContentDivider: Divider(
+                  color: Theme.of(context).primaryColor,
+                ),
                 dropdownSearchDecoration: InputDecoration(
                   hintText: "Select a country",
                   labelText: "Menu mode multiSelection*",

--- a/lib/dropdown_search.dart
+++ b/lib/dropdown_search.dart
@@ -256,6 +256,9 @@ class DropdownSearch<T> extends StatefulWidget {
   ///widget to add custom widget like addAll/removeAll on popup multi selection mode
   final ValidationMultiSelectionBuilder<T>? popupCustomMultiSelectionWidget;
 
+  //widget to place between popup content and buttons
+  final Widget? popupContentDivider;
+
   /// elevation for popup items
   final double popupElevation;
 
@@ -341,6 +344,7 @@ class DropdownSearch<T> extends StatefulWidget {
         this.popupSelectionWidget = null,
         this.popupValidationMultiSelectionWidget = null,
         this.popupCustomMultiSelectionWidget = null,
+        this.popupContentDivider = null,
         super(key: key);
 
   DropdownSearch.multiSelection({
@@ -403,6 +407,7 @@ class DropdownSearch<T> extends StatefulWidget {
     this.popupSelectionWidget,
     this.popupValidationMultiSelectionWidget,
     this.popupCustomMultiSelectionWidget,
+    this.popupContentDivider,
     this.popupElevation = 8,
     this.selectionListViewProps = const SelectionListViewProps(),
     this.focusNode,
@@ -820,6 +825,7 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
       popupValidationMultiSelectionWidget:
           widget.popupValidationMultiSelectionWidget,
       popupCustomMultiSelectionWidget: widget.popupCustomMultiSelectionWidget,
+      popupContentDivider: widget.popupContentDivider,
       isMultiSelectionMode: isMultiSelectionMode,
       selectionListViewProps: widget.selectionListViewProps,
       focusNode: widget.focusNode ?? FocusNode(),

--- a/lib/src/selection_widget.dart
+++ b/lib/src/selection_widget.dart
@@ -80,6 +80,9 @@ class SelectionWidget<T> extends StatefulWidget {
   ///widget to add custom widget like addAll/removeAll on popup multi selection mode
   final ValidationMultiSelectionBuilder<T>? popupCustomMultiSelectionWidget;
 
+  //widget to place between popup content and buttons
+  final Widget? popupContentDivider;
+
   /// props for selection list view
   final SelectionListViewProps selectionListViewProps;
 
@@ -121,6 +124,7 @@ class SelectionWidget<T> extends StatefulWidget {
     this.isMultiSelectionMode = false,
     this.popupValidationMultiSelectionWidget,
     this.popupCustomMultiSelectionWidget,
+    this.popupContentDivider,
     this.selectionListViewProps = const SelectionListViewProps(),
     required this.focusNode,
   }) : super(key: key);
@@ -280,6 +284,7 @@ class SelectionWidgetState<T> extends State<SelectionWidget<T>> {
                     ],
                   ),
                 ),
+                _popupContentDivider(),
                 _multiSelectionValidation(),
               ],
             );
@@ -338,6 +343,10 @@ class SelectionWidgetState<T> extends State<SelectionWidget<T>> {
         popupValidationMultiSelectionWidget(),
       ],
     );
+  }
+
+  Widget _popupContentDivider() {
+    return widget.popupContentDivider ?? Container();
   }
 
   void _showErrorDialog(dynamic error) {


### PR DESCRIPTION
I found a need for a divider between the content and the buttons on the multiselect popup, so I added an optional widget that will be placed between the content and buttons. 

Example has been updated to include it:

![image](https://user-images.githubusercontent.com/9582829/151860705-327209ae-ee61-45d7-b049-da9eeef8544d.png)