### PR TITLE
Add height property for search field and fix shrinkWrap for ListView

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -385,6 +385,8 @@ class _MyHomePageState extends State<MyHomePage> {
                 selectedItem: "Brazil",
                 showSearchBox: true,
                 searchFieldProps: TextFieldProps(
+                  padding: EdgeInsets.fromLTRB(8, 8, 8, 0),
+                  height: 40,
                   decoration: InputDecoration(
                     border: OutlineInputBorder(),
                     contentPadding: EdgeInsets.fromLTRB(12, 12, 8, 0),

--- a/lib/src/properties/text_field_props.dart
+++ b/lib/src/properties/text_field_props.dart
@@ -44,6 +44,7 @@ class TextFieldProps {
     this.keyboardAppearance,
     this.scrollPadding = const EdgeInsets.all(20.0),
     this.padding = const EdgeInsets.all(8.0),
+    this.height,
     this.dragStartBehavior = DragStartBehavior.start,
     this.enableInteractiveSelection = true,
     this.selectionControls,
@@ -132,6 +133,9 @@ class TextFieldProps {
 
   // padding for the search field
   final EdgeInsets padding;
+
+  /// Height of the search field
+  final double? height;
 
   final bool enableInteractiveSelection;
 

--- a/lib/src/selection_widget.dart
+++ b/lib/src/selection_widget.dart
@@ -192,7 +192,7 @@ class SelectionWidgetState<T> extends State<SelectionWidget<T>> {
               children: <Widget>[
                 _searchField(),
                 _favoriteItemsWidget(),
-                Expanded(
+                Flexible(
                   child: Stack(
                     children: <Widget>[
                       StreamBuilder<List<T>>(
@@ -395,7 +395,7 @@ class SelectionWidgetState<T> extends State<SelectionWidget<T>> {
                 ),
               );
           }
-          return Container();
+          return const SizedBox.shrink();
         });
   }
 

--- a/lib/src/selection_widget.dart
+++ b/lib/src/selection_widget.dart
@@ -554,7 +554,8 @@ class SelectionWidgetState<T> extends State<SelectionWidget<T>> {
         children: <Widget>[
           widget.popupTitle ?? const SizedBox.shrink(),
           if (widget.showSearchBox)
-            Padding(
+            Container(
+              height: widget.searchFieldProps?.height,
               padding:
                   widget.searchFieldProps?.padding ?? const EdgeInsets.all(8.0),
               child: DefaultTextEditingShortcuts(


### PR DESCRIPTION
List of fixes:

1. The new property `height` allows to limit height of the search field.
2. Using Flexible instead Expanded for item's ListView, and SizedBox.shrink() instead of Container in `_loadingWidget` will fix the `shrinkWrap` feature when the height of dropdown list is adjusted to total height of selection items when their count is about 1-3.