### PR TITLE
Fix for incorrect instantiation of TextEditingController

### DIFF
--- a/lib/src/properties/text_field_props.dart
+++ b/lib/src/properties/text_field_props.dart
@@ -7,7 +7,7 @@ import 'package:flutter/gestures.dart';
 
 class TextFieldProps {
   TextFieldProps({
-    TextEditingController? controller,
+    this.controller,
     this.decoration,
     this.keyboardType,
     this.textInputAction,
@@ -54,7 +54,7 @@ class TextFieldProps {
     this.scrollPhysics,
     this.autofillHints,
     this.restorationId,
-  }) : this.controller = controller ?? TextEditingController();
+  });
 
   final TextEditingController? controller;
 


### PR DESCRIPTION
Fix for incorrect instantiation of TextEditingController inside TextFieldProps class. The original code causes a) disconnect of listener, which is incorrectly added only during initState and therefore missed if another instance of TextFieldProps is created, and b) as the library creates a TextEditingController, it should dispose of it... but doesn't, so this is always a memory leak. 

Anyway, this change avoids creating the TextEditingController and avoids both a) and b).