### PR TITLE
fix modal bottom sheet height and margin

### DIFF
--- a/lib/dropdown_search.dart
+++ b/lib/dropdown_search.dart
@@ -623,9 +623,10 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
           ).top;
 
           return Container(
+            constraints: BoxConstraints(
+                maxHeight: MediaQuery.of(ctx).size.height - viewPaddingTop),
             margin: EdgeInsets.only(
               bottom: viewInsetsBottom,
-              top: viewPaddingTop,
             ),
             child: _popupWidgetInstance(),
           );


### PR DESCRIPTION
Currently the modal bottom sheet always has a margin on top with the height of the upper safe area (notification bar). This change eliminates the margin and instead limits the bottom sheet height to stop below the notification bar.