### PR TITLE
Added DropdownSearch.multiSelection aboveItemsWidget property

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -314,6 +314,11 @@ class _MyHomePageState extends State<MyHomePage> {
                     child: DropdownSearch<String>.multiSelection(
                       key: _popupBuilderKey,
                       items: List.generate(30, (index) => "$index"),
+                      aboveItemsWidget: Container(
+                        alignment: Alignment.center,
+                        width: double.infinity,
+                        child: Text('Select Items'),
+                      ),
                       popupProps: PopupPropsMultiSelection.dialog(
                         onItemAdded: (l, s) => _handleCheckBoxState(),
                         onItemRemoved: (l, s) => _handleCheckBoxState(),

--- a/lib/dropdown_search.dart
+++ b/lib/dropdown_search.dart
@@ -162,6 +162,8 @@ class DropdownSearch<T> extends StatefulWidget {
   ///if the callBack return FALSE, the opening of the popup will be cancelled
   final BeforePopupOpeningMultiSelection<T>? onBeforePopupOpeningMultiSelection;
 
+  final Widget? aboveItemsWidget;
+
   DropdownSearch({
     Key? key,
     this.onSaved,
@@ -181,6 +183,7 @@ class DropdownSearch<T> extends StatefulWidget {
     this.compareFn,
     this.onBeforeChange,
     this.onBeforePopupOpening,
+    this.aboveItemsWidget,
     PopupProps<T> popupProps = const PopupProps.menu(),
   })  : assert(
           !popupProps.showSelectedItems || T == String || compareFn != null,
@@ -210,6 +213,7 @@ class DropdownSearch<T> extends StatefulWidget {
     this.compareFn,
     this.selectedItems = const [],
     this.popupProps = const PopupPropsMultiSelection.menu(),
+    this.aboveItemsWidget,
     FormFieldSetter<List<T>>? onSaved,
     ValueChanged<List<T>>? onChanged,
     BeforeChangeMultiSelection<T>? onBeforeChange,
@@ -662,6 +666,7 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
       compareFn: widget.compareFn,
       isMultiSelectionMode: isMultiSelectionMode,
       defaultSelectedItems: List.from(getSelectedItems),
+      aboveItemsWidget: widget.aboveItemsWidget,
     );
   }
 

--- a/lib/src/widgets/selection_widget.dart
+++ b/lib/src/widgets/selection_widget.dart
@@ -17,6 +17,7 @@ class SelectionWidget<T> extends StatefulWidget {
   final List<T> defaultSelectedItems;
   final PopupPropsMultiSelection<T> popupProps;
   final bool isMultiSelectionMode;
+  final Widget? aboveItemsWidget;
 
   const SelectionWidget({
     Key? key,
@@ -29,6 +30,7 @@ class SelectionWidget<T> extends StatefulWidget {
     this.itemAsString,
     this.filterFn,
     this.compareFn,
+    this.aboveItemsWidget,
   }) : super(key: key);
 
   @override
@@ -100,6 +102,7 @@ class SelectionWidgetState<T> extends State<SelectionWidget<T>> {
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               _searchField(),
+              if (widget.aboveItemsWidget != null) widget.aboveItemsWidget!,
               _favoriteItemsWidget(),
               Flexible(
                 fit: widget.popupProps.fit,


### PR DESCRIPTION
This adds the possibility of adding a custom widget in between the search field and the items list. 

In my case, I needed this change to add a "Select All" button. I did not want to add it at the top of the popup (like one of the examples) or at the bottom. I wanted to make a custom widget for it to look just like the items on the list, the current properties do not allow this customisation.

I didn't find any contributing guidelines, so let me know if I'm not following any rules, thanks!