### PR TITLE
Adds positioning to ClearButton

### DIFF
--- a/lib/dropdown_search.dart
+++ b/lib/dropdown_search.dart
@@ -456,13 +456,38 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
   Widget _manageSuffixIcons() {
     final clearButtonPressed = () => clear();
     final dropdownButtonPressed = () => _selectSearchMode();
-
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      mainAxisAlignment: MainAxisAlignment.end,
-      children: <Widget>[
-        if (widget.clearButtonProps.isVisible && getSelectedItems.isNotEmpty)
-          IconButton(
+    
+    final Widget? dropdownButton = (widget.dropdownButtonProps.isVisible)
+        ? IconButton(
+            style: widget.dropdownButtonProps.style,
+            isSelected: widget.dropdownButtonProps.isSelected,
+            selectedIcon: widget.dropdownButtonProps.selectedIcon,
+            onPressed:
+                widget.dropdownButtonProps.onPressed ?? dropdownButtonPressed,
+            icon: widget.dropdownButtonProps.icon,
+            constraints: widget.dropdownButtonProps.constraints,
+            hoverColor: widget.dropdownButtonProps.hoverColor,
+            highlightColor: widget.dropdownButtonProps.highlightColor,
+            splashColor: widget.dropdownButtonProps.splashColor,
+            color: widget.dropdownButtonProps.color,
+            focusColor: widget.dropdownButtonProps.focusColor,
+            iconSize: widget.dropdownButtonProps.iconSize,
+            padding: widget.dropdownButtonProps.padding,
+            splashRadius: widget.dropdownButtonProps.splashRadius,
+            alignment: widget.dropdownButtonProps.alignment,
+            autofocus: widget.dropdownButtonProps.autofocus,
+            disabledColor: widget.dropdownButtonProps.disabledColor,
+            enableFeedback: widget.dropdownButtonProps.enableFeedback,
+            focusNode: widget.dropdownButtonProps.focusNode,
+            mouseCursor: widget.dropdownButtonProps.mouseCursor,
+            tooltip: widget.dropdownButtonProps.tooltip,
+            visualDensity: widget.dropdownButtonProps.visualDensity,
+          )
+        : null;
+    
+    final Widget? clearButton = (widget.clearButtonProps.isVisible &&
+            getSelectedItems.isNotEmpty)
+        ? IconButton(
             style: widget.clearButtonProps.style,
             isSelected: widget.clearButtonProps.isSelected,
             selectedIcon: widget.clearButtonProps.selectedIcon,
@@ -485,35 +510,24 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
             mouseCursor: widget.clearButtonProps.mouseCursor,
             tooltip: widget.clearButtonProps.tooltip,
             visualDensity: widget.clearButtonProps.visualDensity,
-          ),
-        if (widget.dropdownButtonProps.isVisible)
-          IconButton(
-            style: widget.dropdownButtonProps.style,
-            isSelected: widget.dropdownButtonProps.isSelected,
-            selectedIcon: widget.dropdownButtonProps.selectedIcon,
-            onPressed: widget.dropdownButtonProps.onPressed ?? dropdownButtonPressed,
-            icon: widget.dropdownButtonProps.icon,
-            constraints: widget.dropdownButtonProps.constraints,
-            hoverColor: widget.dropdownButtonProps.hoverColor,
-            highlightColor: widget.dropdownButtonProps.highlightColor,
-            splashColor: widget.dropdownButtonProps.splashColor,
-            color: widget.dropdownButtonProps.color,
-            focusColor: widget.dropdownButtonProps.focusColor,
-            iconSize: widget.dropdownButtonProps.iconSize,
-            padding: widget.dropdownButtonProps.padding,
-            splashRadius: widget.dropdownButtonProps.splashRadius,
-            alignment: widget.dropdownButtonProps.alignment,
-            autofocus: widget.dropdownButtonProps.autofocus,
-            disabledColor: widget.dropdownButtonProps.disabledColor,
-            enableFeedback: widget.dropdownButtonProps.enableFeedback,
-            focusNode: widget.dropdownButtonProps.focusNode,
-            mouseCursor: widget.dropdownButtonProps.mouseCursor,
-            tooltip: widget.dropdownButtonProps.tooltip,
-            visualDensity: widget.dropdownButtonProps.visualDensity,
-          ),
-      ],
+          )
+        : null;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: widget.clearButtonProps.isBefore
+          ? <Widget>[
+              if (clearButton != null) clearButton,
+              if (dropdownButton != null) dropdownButton,
+            ]
+          : <Widget>[
+              if (dropdownButton != null) dropdownButton,
+              if (clearButton != null) clearButton,
+            ],
     );
   }
+
 
   RelativeRect _position(RenderBox popupButtonObject, RenderBox overlay) {
     // Calculate the show-up area for the dropdown using button's size & position based on the `overlay` used as the coordinate space.

--- a/lib/src/properties/clear_button_props.dart
+++ b/lib/src/properties/clear_button_props.dart
@@ -2,6 +2,11 @@ import 'package:dropdown_search/dropdown_search.dart';
 import 'package:flutter/material.dart';
 
 class ClearButtonProps extends IconButtonProps {
+  /// Used to indicate the buttons order when the field is not empty
+  /// If `true` (default) the clear button is before the dropdown button
+  /// If `false` the dropdown button is before the clear button
+  final bool isBefore;
+
   const ClearButtonProps({
     super.icon = const Icon(Icons.clear, size: 24),
     super.isVisible = false,
@@ -26,5 +31,6 @@ class ClearButtonProps extends IconButtonProps {
     super.isSelected,
     super.selectedIcon,
     super.onPressed,
+    this.isBefore = true,
   });
 }


### PR DESCRIPTION
This PR adds to ability to position the clear button relative to the dropdown button (before or after).

Comparing the `DropdownSearch` widget to the native `DropdownButtonFormField` the clear buttons are in different position (see image below)

<img width="367" alt="image" src="https://github.com/salim-lachdhaf/searchable_dropdown/assets/26971763/9de1510d-5ef3-4dea-8521-662cc4cbbbc5">


With this PR, adding the property `isBefore` and setting it to `false` makes it possible to switch the positions:

<img width="367" alt="image" src="https://github.com/salim-lachdhaf/searchable_dropdown/assets/26971763/568475b9-c87a-494a-b2a6-ca8048ca8246">
