### PR TITLE
fix: dropdown builder should not return widget if selected item is null

### DIFF
--- a/lib/dropdown_search.dart
+++ b/lib/dropdown_search.dart
@@ -384,10 +384,10 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
                 baseStyle: widget.dropdownDecoratorProps.baseStyle,
                 textAlign: widget.dropdownDecoratorProps.textAlign,
                 textAlignVertical: widget.dropdownDecoratorProps.textAlignVertical,
-                isEmpty: getSelectedItem == null && widget.dropdownBuilder == null,
+                isEmpty: getSelectedItem == null,
                 isFocused: isFocused,
                 decoration: _manageDropdownDecoration(state),
-                child: _defaultSelectedItemWidget(),
+                child:(getSelectedItem!=null)? _defaultSelectedItemWidget():null,
               );
             });
       },
@@ -416,10 +416,10 @@ class DropdownSearchState<T> extends State<DropdownSearch<T>> {
                 baseStyle: widget.dropdownDecoratorProps.baseStyle,
                 textAlign: widget.dropdownDecoratorProps.textAlign,
                 textAlignVertical: widget.dropdownDecoratorProps.textAlignVertical,
-                isEmpty: getSelectedItems.isEmpty && widget.dropdownBuilderMultiSelection == null,
+                isEmpty: getSelectedItems.isEmpty,
                 isFocused: isFocused,
                 decoration: _manageDropdownDecoration(state),
-                child: _defaultSelectedItemWidget(),
+                child:(getSelectedItems.isNotEmpty)? _defaultSelectedItemWidget():null,
               );
             });
       },


### PR DESCRIPTION
**Description**:
This pull request solves the issue of dropdownBuilder field returning a widget even when no item is selected.
This PR also closes [#515 ](https://github.com/salim-lachdhaf/searchable_dropdown/issues/515)
For example:
Before:
```dart
              DropdownSearch(
                items: ["Test1", "Test2"],
                dropdownDecoratorProps: DropDownDecoratorProps(
                  dropdownSearchDecoration: InputDecoration(
                    labelText: "Enter Name",
                    labelStyle: TextStyle(color: Colors.black45),
                    border: OutlineInputBorder(
                      borderSide: const BorderSide(
                          color: Colors.deepPurple, width: 1.0),
                      borderRadius: BorderRadius.circular(8),
                    ),
                  ),
                ),
                dropdownBuilder: (context, selectedItem) {
                  return Text(selectedItem.toString());
                },
              ),
```
Here even when non of the items are selected we will see null text.
<img src="https://github.com/salim-lachdhaf/searchable_dropdown/assets/67099170/e5405fbb-2678-47e0-86f8-2e2d94927d16"  width="300" height="70">
<img src="https://github.com/salim-lachdhaf/searchable_dropdown/assets/67099170/e1393a98-7c1d-48d6-a221-7552ebd65d1a"  width="300" height="150">

After: Here we can see that only label is shown not our Text() widget as selectedItem is null.
<img src="https://github.com/salim-lachdhaf/searchable_dropdown/assets/67099170/95044c46-1401-415e-8471-9e1b73c83ff3"  width="300" height="60">
<img src="https://github.com/salim-lachdhaf/searchable_dropdown/assets/67099170/d1d5b54b-c987-46bc-9c71-3bcb3d0f6c97"  width="300" height="60">
