### PR TITLE
fix filled and custom shape textField issue

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -307,24 +307,6 @@ class _MyHomePageState extends State<MyHomePage> {
                   )
                 ],
               ),
-              Row(
-                children: [
-                  Expanded(
-                    child: DropdownMenu(
-                      dropdownMenuEntries:
-                          [1, 2, 3, 4, 5, 6, 7].map((e) => DropdownMenuEntry(value: e, label: e.toString())).toList(),
-                      inputDecorationTheme: InputDecorationTheme(
-                        filled: true,
-                        border: OutlineInputBorder(
-                          borderSide: BorderSide.none,
-                          borderRadius: BorderRadius.circular(20),
-                        ),
-                      ),
-                      errorText: 'test',
-                    ),
-                  ),
-                ],
-              ),
 
               ///************************[custom popup background examples]********************************///
               Padding(padding: EdgeInsets.all(8)),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -257,6 +257,75 @@ class _MyHomePageState extends State<MyHomePage> {
                 ],
               ),
 
+              ///************************[custom shape examples]********************************///
+              Padding(padding: EdgeInsets.all(8)),
+              Text("[custom shape examples]"),
+              Divider(),
+              Row(
+                children: [
+                  Expanded(
+                    child: DropdownSearch<int>(
+                      items: [1, 2, 3, 4, 5, 6, 7],
+                      autoValidateMode: AutovalidateMode.onUserInteraction,
+                      validator: (int? i) {
+                        if (i == null)
+                          return 'required filed';
+                        else if (i >= 5) return 'value should be < 5';
+                        return null;
+                      },
+                      clearButtonProps: ClearButtonProps(isVisible: true),
+                      dropdownDecoratorProps: DropDownDecoratorProps(
+                        dropdownSearchDecoration: InputDecoration(
+                          filled: true,
+                          border: OutlineInputBorder(
+                            borderSide: BorderSide.none,
+                            borderRadius: BorderRadius.circular(20),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  Padding(padding: EdgeInsets.all(4)),
+                  Expanded(
+                    child: DropdownSearch<int>.multiSelection(
+                      items: [1, 2, 3, 4, 5, 6, 7],
+                      validator: (List<int>? items) {
+                        if (items == null || items.isEmpty)
+                          return 'required filed';
+                        else if (items.length > 3) return 'only 1 to 3 items are allowed';
+                        return null;
+                      },
+                      dropdownDecoratorProps: DropDownDecoratorProps(
+                        dropdownSearchDecoration: InputDecoration(
+                          border: OutlineInputBorder(
+                            borderSide: BorderSide(),
+                            borderRadius: BorderRadius.circular(20),
+                          ),
+                        ),
+                      ),
+                    ),
+                  )
+                ],
+              ),
+              Row(
+                children: [
+                  Expanded(
+                    child: DropdownMenu(
+                      dropdownMenuEntries:
+                          [1, 2, 3, 4, 5, 6, 7].map((e) => DropdownMenuEntry(value: e, label: e.toString())).toList(),
+                      inputDecorationTheme: InputDecorationTheme(
+                        filled: true,
+                        border: OutlineInputBorder(
+                          borderSide: BorderSide.none,
+                          borderRadius: BorderRadius.circular(20),
+                        ),
+                      ),
+                      errorText: 'test',
+                    ),
+                  ),
+                ],
+              ),
+
               ///************************[custom popup background examples]********************************///
               Padding(padding: EdgeInsets.all(8)),
               Text("[custom popup background examples]"),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -15,7 +15,7 @@ version: 1.0.0+1
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.12.0 <=3.0.0"
+  sdk: ">=2.12.0 <=4.0.0"
 
 dependencies:
   dio: ^4.0.0

--- a/lib/src/properties/dropdown_decorator_props.dart
+++ b/lib/src/properties/dropdown_decorator_props.dart
@@ -1,13 +1,16 @@
+import 'package:dropdown_search/src/properties/ink_well_props.dart';
 import 'package:flutter/material.dart';
 
 class DropDownDecoratorProps {
   final InputDecoration? dropdownSearchDecoration;
+  final InkWellProps? inkWellProps;
   final TextStyle? baseStyle;
   final TextAlign? textAlign;
   final TextAlignVertical? textAlignVertical;
 
   const DropDownDecoratorProps({
     this.dropdownSearchDecoration,
+    this.inkWellProps,
     this.baseStyle,
     this.textAlign,
     this.textAlignVertical,

--- a/lib/src/properties/ink_well_props.dart
+++ b/lib/src/properties/ink_well_props.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+
+class InkWellProps {
+  final BoxShape? highlightShape;
+  final double? radius;
+  final BorderRadius? borderRadius;
+  final ShapeBorder? customBorder;
+  final Color? focusColor;
+  final Color? hoverColor;
+  final Color? highlightColor;
+  final WidgetStateProperty<Color?>? overlayColor;
+  final Color? splashColor;
+  final InteractiveInkFeatureFactory? splashFactory;
+  final bool? enableFeedback;
+  final bool excludeFromSemantics;
+  final bool autofocus;
+  final bool canRequestFocus;
+  final Duration? hoverDuration;
+
+  const InkWellProps({
+    this.highlightShape,
+    this.radius,
+    this.borderRadius,
+    this.customBorder,
+    this.focusColor,
+    this.hoverColor,
+    this.highlightColor,
+    this.overlayColor,
+    this.splashColor,
+    this.splashFactory,
+    this.enableFeedback,
+    this.excludeFromSemantics = false,
+    this.canRequestFocus = true,
+    this.autofocus = false,
+    this.hoverDuration,
+  });
+
+  InkWellProps copyWith({
+    BoxShape? highlightShape,
+    double? radius,
+    BorderRadius? borderRadius,
+    ShapeBorder? customBorder,
+    Color? focusColor,
+    Color? hoverColor,
+    Color? highlightColor,
+    WidgetStateProperty<Color?>? overlayColor,
+    Color? splashColor,
+    InteractiveInkFeatureFactory? splashFactory,
+    bool? enableFeedback,
+    bool? excludeFromSemantics,
+    bool? autofocus,
+    bool? canRequestFocus,
+    Duration? hoverDuration,
+  }) {
+    return InkWellProps(
+      highlightShape: highlightShape ?? this.highlightShape,
+      radius: radius ?? this.radius,
+      borderRadius: borderRadius ?? this.borderRadius,
+      customBorder: customBorder ?? this.customBorder,
+      focusColor: focusColor ?? this.focusColor,
+      hoverColor: hoverColor ?? this.hoverColor,
+      highlightColor: highlightColor ?? this.highlightColor,
+      overlayColor: overlayColor ?? this.overlayColor,
+      splashColor: splashColor ?? this.splashColor,
+      splashFactory: splashFactory ?? this.splashFactory,
+      enableFeedback: enableFeedback ?? this.enableFeedback,
+      excludeFromSemantics: excludeFromSemantics ?? this.excludeFromSemantics,
+      canRequestFocus: canRequestFocus ?? this.canRequestFocus,
+      autofocus: autofocus ?? this.autofocus,
+      hoverDuration: hoverDuration ?? this.hoverDuration,
+    );
+  }
+
+  InkWellProps applyDefaults(InkWellProps defaults) {
+    return copyWith(
+      highlightShape: this.highlightShape ?? defaults.highlightShape,
+      radius: this.radius ?? defaults.radius,
+      borderRadius: this.borderRadius ?? defaults.borderRadius,
+      customBorder: this.customBorder ?? defaults.customBorder,
+      focusColor: this.focusColor ?? defaults.focusColor,
+      hoverColor: this.hoverColor ?? defaults.hoverColor,
+      highlightColor: this.highlightColor ?? defaults.highlightColor,
+      overlayColor: this.overlayColor ?? defaults.overlayColor,
+      splashColor: this.splashColor ?? defaults.splashColor,
+      splashFactory: this.splashFactory ?? defaults.splashFactory,
+      enableFeedback: this.enableFeedback ?? defaults.enableFeedback,
+      excludeFromSemantics: this.excludeFromSemantics,
+      canRequestFocus: this.canRequestFocus,
+      autofocus: this.autofocus,
+      hoverDuration: this.hoverDuration ?? defaults.hoverDuration,
+    );
+  }
+}
+
+const defautlInkWellProps = InkWellProps(
+  focusColor: Colors.transparent,
+  hoverColor: Colors.transparent,
+  highlightColor: Colors.transparent,
+  overlayColor: WidgetStatePropertyAll(Colors.transparent),
+  splashColor: Colors.transparent,
+  enableFeedback: true,
+  excludeFromSemantics: true,
+  canRequestFocus: false,
+);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ git: https://github.com/salim-lachdhaf/searchable_dropdown
 repository: https://github.com/salim-lachdhaf/searchable_dropdown
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
 
 
 dependencies:


### PR DESCRIPTION
In the current version, there are issues with the hover effect protruding when there is an error message or a custom-shaped text field.

Several reasons contribute to this erroneous behavior, and I have fixed them in my pull request:

The hovered state was not being propagated from InkWell to InputDecorator. As a result, when filled: true was set, the hover effect was not visible.
The hover effect from InkWell was also capturing the error field. Therefore, I added the InkWellProps class with default values to hide these effects. The visual behavior is now closer to Material.DropdownMenu.

Additionally, I have introduced the possibility of customizing the InkWell behavior.

master:
<img width="577" alt="image" src="https://github.com/user-attachments/assets/c678352c-40a4-4fb1-bce2-6717795f3962">
<img width="579" alt="image" src="https://github.com/user-attachments/assets/409a646d-11ac-4812-b7ed-6f03f764a172">

pull request:
<img width="584" alt="image" src="https://github.com/user-attachments/assets/a86b5328-88c8-41c1-8623-9df8f89c6e18">
<img width="593" alt="image" src="https://github.com/user-attachments/assets/944453c6-8206-41ab-8132-c36ce7d937e9">


