### PR TITLE
DropdownButtonProps default animation builder

### DIFF
--- a/lib/src/base_dropdown_search.dart
+++ b/lib/src/base_dropdown_search.dart
@@ -676,16 +676,8 @@ class DropdownSearchState<T> extends State<BaseDropdownSearch<T>> {
     }
 
     Widget? getDropdownButton() {
-      final dropDownButton = widget.suffixProps.dropdownButtonProps ??
-          DropdownButtonProps(
-            animationBuilder: (child, isOpen) {
-              return AnimatedRotation(
-                turns: isOpen ? .5 : 1,
-                duration: Duration(milliseconds: 300),
-                child: child,
-              );
-            },
-          );
+      final dropDownButton =
+          widget.suffixProps.dropdownButtonProps ?? DropdownButtonProps();
       if (!dropDownButton.isVisible) return null;
 
       //icon required
@@ -705,11 +697,7 @@ class DropdownSearchState<T> extends State<BaseDropdownSearch<T>> {
         onPressed: () => toggleDropDownSearch(),
       );
 
-      if (dropDownButton.animationBuilder != null) {
-        return dropDownButton.animationBuilder!(button, isFocused);
-      }
-
-      return button;
+      return dropDownButton.animationBuilder(button, isFocused);
     }
 
     final dropdownButton = getDropdownButton();

--- a/lib/src/properties/dropdown_props.dart
+++ b/lib/src/properties/dropdown_props.dart
@@ -5,14 +5,22 @@ import 'package:flutter/material.dart';
 typedef DropdownButtonAnimationBuilder = Widget Function(
     Widget child, bool isOpen);
 
+Widget defaultAnimationBuilder(child, isOpen) {
+  return AnimatedRotation(
+    turns: isOpen ? .5 : 1,
+    duration: Duration(milliseconds: 300),
+    child: child,
+  );
+}
+
 class DropdownButtonProps extends IconButtonProps {
   final Widget? iconOpened;
-  final DropdownButtonAnimationBuilder? animationBuilder;
+  final DropdownButtonAnimationBuilder animationBuilder;
 
   const DropdownButtonProps({
     this.iconOpened,
     Widget? iconClosed,
-    this.animationBuilder,
+    this.animationBuilder = defaultAnimationBuilder,
     super.isVisible = true,
     super.iconSize,
     super.visualDensity,


### PR DESCRIPTION
Hi @salim-lachdhaf 

Due to this code

```dart
final dropDownButton = widget.suffixProps.dropdownButtonProps ??
          DropdownButtonProps(
            animationBuilder: (child, isOpen) {
              return AnimatedRotation(
                turns: isOpen ? .5 : 1,
                duration: Duration(milliseconds: 300),
                child: child,
              );
            },
          );
```

if user passes some `widget.suffixProps.dropdownButtonProps` it immediately looses `animationBuilder` cause there is no default one in `DropdownButtonProps`