### PR TITLE
itemBuilder onTap param pass through

### DIFF
--- a/example/lib/adaptive/autocomplete.dart
+++ b/example/lib/adaptive/autocomplete.dart
@@ -77,7 +77,7 @@ class _AdaptiveAutocompleteExamplesPageState
                             constraints: BoxConstraints(minWidth: 128),
                             fit: FlexFit.loose,
                             itemBuilder:
-                                (context, item, isDisabled, isSelected) =>
+                                (context, item, isDisabled, isSelected, _) =>
                                     Padding(
                               padding: const EdgeInsets.all(8.0),
                               child: Text(item.$1,
@@ -173,7 +173,7 @@ class _AdaptiveAutocompleteExamplesPageState
                             groupId: UniqueKey(),
                           ),
                           showSelectedItems: true,
-                          itemBuilder: (ctx, item, isDisabled, isSelected) {
+                          itemBuilder: (ctx, item, isDisabled, isSelected, _) {
                             return ListTile(
                               leading: CircleAvatar(
                                   backgroundColor: Colors.blue,
@@ -252,7 +252,7 @@ class _AdaptiveAutocompleteExamplesPageState
                       },
                       popupProps: AdaptivePopupProps(
                           materialProps: PopupProps.autocomplete(
-                        itemBuilder: (context, item, isDisabled, isSelected) {
+                        itemBuilder: (context, item, isDisabled, isSelected, _) {
                           return ListTile(
                             contentPadding: EdgeInsets.symmetric(
                                 vertical: 8, horizontal: 12),
@@ -347,7 +347,7 @@ class _AdaptiveAutocompleteExamplesPageState
                       },
                       popupProps: AdaptivePopupProps(
                           cupertinoProps: CupertinoPopupProps.autocomplete(
-                        itemBuilder: (context, item, isDisabled, isSelected) {
+                        itemBuilder: (context, item, isDisabled, isSelected, _) {
                           return Padding(
                             padding: const EdgeInsets.symmetric(vertical: 12.0),
                             child: Text(

--- a/example/lib/adaptive/bottom_sheets.dart
+++ b/example/lib/adaptive/bottom_sheets.dart
@@ -310,7 +310,7 @@ class _AdaptiveBottomSheetExamplesPageState
                     materialProps: PopupProps.bottomSheet(
                       showSelectedItems: true,
                       interceptCallBacks: true, //important line
-                      itemBuilder: (ctx, item, isDisabled, isSelected) {
+                      itemBuilder: (ctx, item, isDisabled, isSelected, _) {
                         return ListTile(
                           selected: isSelected,
                           title: Text(item.level1),

--- a/example/lib/adaptive/dialogs.dart
+++ b/example/lib/adaptive/dialogs.dart
@@ -317,7 +317,7 @@ class _AdaptiveDialogExamplesPageState
                   materialProps: PopupProps.dialog(
                     showSelectedItems: true,
                     interceptCallBacks: true, //important line
-                    itemBuilder: (ctx, item, isDisabled, isSelected) {
+                    itemBuilder: (ctx, item, isDisabled, isSelected, _) {
                       return ListTile(
                         selected: isSelected,
                         title: Text(item.level1),
@@ -537,7 +537,12 @@ Widget customDropDownExampleMultiSelection(
 }
 
 Widget userModelPopupItem(
-    BuildContext context, UserModel item, bool isDisabled, bool isSelected) {
+  BuildContext context,
+  UserModel item,
+  bool isDisabled,
+  bool isSelected,
+  _,
+) {
   return Container(
     margin: EdgeInsets.symmetric(horizontal: 8),
     decoration: !isSelected

--- a/example/lib/adaptive/menus.dart
+++ b/example/lib/adaptive/menus.dart
@@ -68,7 +68,7 @@ class _AdaptiveMenuExamplesPageState extends State<AdaptiveMenuExamplesPage> {
                       menuProps: MenuProps(align: MenuAlign.bottomCenter),
                       constraints: BoxConstraints(minWidth: 128),
                       fit: FlexFit.loose,
-                      itemBuilder: (context, item, isDisabled, isSelected) =>
+                      itemBuilder: (context, item, isDisabled, isSelected, _) =>
                           Padding(
                         padding: const EdgeInsets.all(8.0),
                         child: Text(item.$1,
@@ -189,7 +189,7 @@ class _AdaptiveMenuExamplesPageState extends State<AdaptiveMenuExamplesPage> {
                               true, //data will be filtered by the backend
                           showSearchBox: true,
                           showSelectedItems: true,
-                          itemBuilder: (ctx, item, isDisabled, isSelected) {
+                          itemBuilder: (ctx, item, isDisabled, isSelected, _) {
                             return ListTile(
                               leading: CircleAvatar(
                                   backgroundColor: Colors.blue,
@@ -264,7 +264,7 @@ class _AdaptiveMenuExamplesPageState extends State<AdaptiveMenuExamplesPage> {
                       },
                       popupProps: AdaptivePopupProps(
                         materialProps: PopupProps.menu(
-                          itemBuilder: (context, item, isDisabled, isSelected) {
+                          itemBuilder: (context, item, isDisabled, isSelected, _) {
                             return ListTile(
                               contentPadding: EdgeInsets.symmetric(
                                   vertical: 8, horizontal: 12),
@@ -351,7 +351,7 @@ class _AdaptiveMenuExamplesPageState extends State<AdaptiveMenuExamplesPage> {
                       ),
                       popupProps: AdaptivePopupProps(
                         materialProps: PopupProps.menu(
-                          itemBuilder: (context, item, isDisabled, isSelected) {
+                          itemBuilder: (context, item, isDisabled, isSelected, _) {
                             return Padding(
                               padding:
                                   const EdgeInsets.symmetric(vertical: 12.0),

--- a/example/lib/adaptive/modals.dart
+++ b/example/lib/adaptive/modals.dart
@@ -303,7 +303,7 @@ class _AdaptiveModalsExamplesPageState
                   cupertinoProps: CupertinoPopupProps.modalBottomSheet(
                     showSelectedItems: true,
                     interceptCallBacks: true, //important line
-                    itemBuilder: (ctx, item, isDisabled, isSelected) {
+                    itemBuilder: (ctx, item, isDisabled, isSelected, _) {
                       return ListTile(
                         selected: isSelected,
                         title: Text(item.level1),

--- a/example/lib/cupertino/autocomplete.dart
+++ b/example/lib/cupertino/autocomplete.dart
@@ -72,7 +72,7 @@ class _CupertinoAutocompleteExamplesPageState
                             groupId: UniqueKey()),
                         constraints: BoxConstraints(minWidth: 128),
                         fit: FlexFit.loose,
-                        itemBuilder: (context, item, isDisabled, isSelected) =>
+                        itemBuilder: (context, item, isDisabled, isSelected, _) =>
                             Padding(
                           padding: const EdgeInsets.all(8.0),
                           child: Text(item.$1,
@@ -159,7 +159,7 @@ class _CupertinoAutocompleteExamplesPageState
                           groupId: UniqueKey(),
                         ),
                         showSelectedItems: true,
-                        itemBuilder: (ctx, item, isDisabled, isSelected) {
+                        itemBuilder: (ctx, item, isDisabled, isSelected, _) {
                           return ListTile(
                             leading: CircleAvatar(
                                 backgroundColor: Colors.blue,
@@ -235,7 +235,7 @@ class _CupertinoAutocompleteExamplesPageState
                         ]);
                       },
                       popupProps: CupertinoPopupProps.autocomplete(
-                        itemBuilder: (context, item, isDisabled, isSelected) {
+                        itemBuilder: (context, item, isDisabled, isSelected, _) {
                           return ListTile(
                             contentPadding: EdgeInsets.symmetric(
                                 vertical: 8, horizontal: 12),
@@ -328,7 +328,7 @@ class _CupertinoAutocompleteExamplesPageState
                         );
                       },
                       popupProps: CupertinoPopupProps.autocomplete(
-                        itemBuilder: (context, item, isDisabled, isSelected) {
+                        itemBuilder: (context, item, isDisabled, isSelected, _) {
                           return Padding(
                             padding: const EdgeInsets.symmetric(vertical: 12.0),
                             child: Text(

--- a/example/lib/cupertino/bottom_sheets.dart
+++ b/example/lib/cupertino/bottom_sheets.dart
@@ -276,7 +276,7 @@ class _CupertinoBottomSheetExamplesPageState
                 popupProps: CupertinoPopupProps.bottomSheet(
                   showSelectedItems: true,
                   interceptCallBacks: true, //important line
-                  itemBuilder: (ctx, item, isDisabled, isSelected) {
+                  itemBuilder: (ctx, item, isDisabled, isSelected, _) {
                     return ListTile(
                       selected: isSelected,
                       title: Text(item.level1),

--- a/example/lib/cupertino/dialogs.dart
+++ b/example/lib/cupertino/dialogs.dart
@@ -275,7 +275,7 @@ class _CupertinoDialogExamplesPageState
                 popupProps: CupertinoPopupProps.dialog(
                   showSelectedItems: true,
                   interceptCallBacks: true, //important line
-                  itemBuilder: (ctx, item, isDisabled, isSelected) {
+                  itemBuilder: (ctx, item, isDisabled, isSelected, _) {
                     return ListTile(
                       selected: isSelected,
                       title: Text(item.level1),
@@ -486,7 +486,7 @@ Widget customDropDownExampleMultiSelection(
 }
 
 Widget userModelPopupItem(
-    BuildContext context, UserModel item, bool isDisabled, bool isSelected) {
+    BuildContext context, UserModel item, bool isDisabled, bool isSelected, _) {
   return Container(
     decoration: !isSelected
         ? null

--- a/example/lib/cupertino/menus.dart
+++ b/example/lib/cupertino/menus.dart
@@ -64,7 +64,7 @@ class _CupertinoMenuExamplesPageState extends State<CupertinoMenuExamplesPage> {
                           CupertinoMenuProps(align: MenuAlign.bottomCenter),
                       constraints: BoxConstraints(minWidth: 128),
                       fit: FlexFit.loose,
-                      itemBuilder: (context, item, isDisabled, isSelected) =>
+                      itemBuilder: (context, item, isDisabled, isSelected, _) =>
                           Padding(
                         padding: const EdgeInsets.all(8.0),
                         child: Text(item.$1,
@@ -178,7 +178,7 @@ class _CupertinoMenuExamplesPageState extends State<CupertinoMenuExamplesPage> {
                             true, //data will be filtered by the backend
                         showSearchBox: true,
                         showSelectedItems: true,
-                        itemBuilder: (ctx, item, isDisabled, isSelected) {
+                        itemBuilder: (ctx, item, isDisabled, isSelected, _) {
                           return ListTile(
                             leading: CircleAvatar(
                                 backgroundColor: Colors.blue,
@@ -250,7 +250,7 @@ class _CupertinoMenuExamplesPageState extends State<CupertinoMenuExamplesPage> {
                         );
                       },
                       popupProps: CupertinoPopupProps.menu(
-                        itemBuilder: (context, item, isDisabled, isSelected) {
+                        itemBuilder: (context, item, isDisabled, isSelected, _) {
                           return ListTile(
                             contentPadding: EdgeInsets.symmetric(
                                 vertical: 8, horizontal: 12),
@@ -334,7 +334,7 @@ class _CupertinoMenuExamplesPageState extends State<CupertinoMenuExamplesPage> {
                         ),
                       ),
                       popupProps: CupertinoPopupProps.menu(
-                        itemBuilder: (context, item, isDisabled, isSelected) {
+                        itemBuilder: (context, item, isDisabled, isSelected, _) {
                           return Padding(
                             padding: const EdgeInsets.symmetric(vertical: 12.0),
                             child: Text(

--- a/example/lib/cupertino/modals.dart
+++ b/example/lib/cupertino/modals.dart
@@ -278,7 +278,7 @@ class _CupertinoModalsExamplesPageState
                 popupProps: CupertinoPopupProps.modalBottomSheet(
                   showSelectedItems: true,
                   interceptCallBacks: true, //important line
-                  itemBuilder: (ctx, item, isDisabled, isSelected) {
+                  itemBuilder: (ctx, item, isDisabled, isSelected, _) {
                     return ListTile(
                       selected: isSelected,
                       title: Text(item.level1),

--- a/example/lib/material/autocomplete.dart
+++ b/example/lib/material/autocomplete.dart
@@ -71,7 +71,7 @@ class _MaterialAutocompleteExamplesPageState
                             groupId: UniqueKey()),
                         constraints: BoxConstraints(minWidth: 128),
                         fit: FlexFit.loose,
-                        itemBuilder: (context, item, isDisabled, isSelected) =>
+                        itemBuilder: (context, item, isDisabled, isSelected, _) =>
                             Padding(
                           padding: const EdgeInsets.all(8.0),
                           child: Text(item.$1,
@@ -157,7 +157,7 @@ class _MaterialAutocompleteExamplesPageState
                           groupId: UniqueKey(),
                         ),
                         showSelectedItems: true,
-                        itemBuilder: (ctx, item, isDisabled, isSelected) {
+                        itemBuilder: (ctx, item, isDisabled, isSelected, _) {
                           return ListTile(
                             leading: CircleAvatar(
                                 backgroundColor: Colors.blue,
@@ -233,7 +233,7 @@ class _MaterialAutocompleteExamplesPageState
                         ]);
                       },
                       popupProps: PopupProps.autocomplete(
-                        itemBuilder: (context, item, isDisabled, isSelected) {
+                        itemBuilder: (context, item, isDisabled, isSelected, _) {
                           return ListTile(
                             contentPadding: EdgeInsets.symmetric(
                                 vertical: 8, horizontal: 12),
@@ -326,7 +326,7 @@ class _MaterialAutocompleteExamplesPageState
                         );
                       },
                       popupProps: PopupProps.autocomplete(
-                        itemBuilder: (context, item, isDisabled, isSelected) {
+                        itemBuilder: (context, item, isDisabled, isSelected, _) {
                           return Padding(
                             padding: const EdgeInsets.symmetric(vertical: 12.0),
                             child: Text(

--- a/example/lib/material/bottom_sheets.dart
+++ b/example/lib/material/bottom_sheets.dart
@@ -287,7 +287,7 @@ class _MaterialBottomSheetExamplesPageState
                 popupProps: PopupProps.bottomSheet(
                   showSelectedItems: true,
                   interceptCallBacks: true, //important line
-                  itemBuilder: (ctx, item, isDisabled, isSelected) {
+                  itemBuilder: (ctx, item, isDisabled, isSelected, _) {
                     return ListTile(
                       selected: isSelected,
                       title: Text(item.level1),

--- a/example/lib/material/dialogs.dart
+++ b/example/lib/material/dialogs.dart
@@ -295,7 +295,7 @@ class _MaterialDialogExamplesPageState
                 popupProps: PopupProps.dialog(
                   showSelectedItems: true,
                   interceptCallBacks: true, //important line
-                  itemBuilder: (ctx, item, isDisabled, isSelected) {
+                  itemBuilder: (ctx, item, isDisabled, isSelected, _) {
                     return ListTile(
                       selected: isSelected,
                       title: Text(item.level1),
@@ -511,7 +511,7 @@ Widget customDropDownExampleMultiSelection(
 }
 
 Widget userModelPopupItem(
-    BuildContext context, UserModel item, bool isDisabled, bool isSelected) {
+    BuildContext context, UserModel item, bool isDisabled, bool isSelected, _) {
   return Container(
     margin: EdgeInsets.symmetric(horizontal: 8),
     decoration: !isSelected

--- a/example/lib/material/menus.dart
+++ b/example/lib/material/menus.dart
@@ -63,7 +63,7 @@ class _MaterialMenuExamplesPageState extends State<MaterialMenuExamplesPage> {
                       menuProps: MenuProps(align: MenuAlign.bottomCenter),
                       constraints: BoxConstraints(minWidth: 128),
                       fit: FlexFit.loose,
-                      itemBuilder: (context, item, isDisabled, isSelected) =>
+                      itemBuilder: (context, item, isDisabled, isSelected, _) =>
                           Padding(
                         padding: const EdgeInsets.all(8.0),
                         child: Text(item.$1,
@@ -177,7 +177,7 @@ class _MaterialMenuExamplesPageState extends State<MaterialMenuExamplesPage> {
                             true, //data will be filtered by the backend
                         showSearchBox: true,
                         showSelectedItems: true,
-                        itemBuilder: (ctx, item, isDisabled, isSelected) {
+                        itemBuilder: (ctx, item, isDisabled, isSelected, _) {
                           return ListTile(
                             leading: CircleAvatar(
                                 backgroundColor: Colors.blue,
@@ -249,7 +249,7 @@ class _MaterialMenuExamplesPageState extends State<MaterialMenuExamplesPage> {
                         );
                       },
                       popupProps: PopupProps.menu(
-                        itemBuilder: (context, item, isDisabled, isSelected) {
+                        itemBuilder: (context, item, isDisabled, isSelected, _) {
                           return ListTile(
                             contentPadding: EdgeInsets.symmetric(
                                 vertical: 8, horizontal: 12),
@@ -333,7 +333,7 @@ class _MaterialMenuExamplesPageState extends State<MaterialMenuExamplesPage> {
                         ),
                       ),
                       popupProps: PopupProps.menu(
-                        itemBuilder: (context, item, isDisabled, isSelected) {
+                        itemBuilder: (context, item, isDisabled, isSelected, _) {
                           return Padding(
                             padding: const EdgeInsets.symmetric(vertical: 12.0),
                             child: Text(

--- a/example/lib/material/modals.dart
+++ b/example/lib/material/modals.dart
@@ -270,7 +270,7 @@ class _MaterialModalsExamplesPageState
                 popupProps: PopupProps.modalBottomSheet(
                   showSelectedItems: true,
                   interceptCallBacks: true, //important line
-                  itemBuilder: (ctx, item, isDisabled, isSelected) {
+                  itemBuilder: (ctx, item, isDisabled, isSelected, _) {
                     return ListTile(
                       selected: isSelected,
                       title: Text(item.level1),

--- a/lib/src/base_dropdown_search.dart
+++ b/lib/src/base_dropdown_search.dart
@@ -28,7 +28,12 @@ typedef DropdownSearchBuilder<T> = Widget Function(
 typedef DropdownSearchBuilderMultiSelection<T> = Widget Function(
     BuildContext context, List<T> selectedItems);
 typedef DropdownSearchPopupItemBuilder<T> = Widget Function(
-    BuildContext context, T item, bool isDisabled, bool isSelected);
+  BuildContext context,
+  T item,
+  bool isDisabled,
+  bool isSelected,
+  void Function(T item) onTap,
+);
 typedef DropdownSearchPopupItemEnabled<T> = bool Function(T item);
 typedef ErrorBuilder = Widget Function(
     BuildContext context, String searchEntry, dynamic exception);

--- a/lib/src/widgets/dropdown_search_popup.dart
+++ b/lib/src/widgets/dropdown_search_popup.dart
@@ -497,6 +497,7 @@ class DropdownSearchPopupState<T> extends State<DropdownSearchPopup<T>> {
         item,
         isDisabled,
         !widget.props.showSelectedItems ? false : _isSelectedItem(item),
+        _handleSelectedItem,
       );
 
       if (widget.props.interceptCallBacks) return w;
@@ -524,7 +525,13 @@ class DropdownSearchPopupState<T> extends State<DropdownSearchPopup<T>> {
       return CheckBoxWidget(
         clickProps: widget.props.itemClickProps,
         checkBox: (cxt, checked) {
-          return widget.props.checkBoxBuilder!(cxt, item, isDisabled, checked);
+          return widget.props.checkBoxBuilder!(
+            cxt,
+            item,
+            isDisabled,
+            checked,
+            _handleSelectedItem,
+          );
         },
         interceptCallBacks: widget.props.interceptCallBacks,
         textDirection: widget.props.textDirection,


### PR DESCRIPTION
Hi @salim-lachdhaf 

While using `interceptCallBacks: true` it becomes tricky to make a custom tap event handling for the list item

this PR adds an fn pass through to simplify implementation

```dart
      interceptCallBacks: true,
      itemBuilder: (_, item, isDisabled, isSelected, onTap) {
            return CustomListTile(
                  title: TextCap(itemAsString?.call(item) ?? item.toString()),
                  selected: isSelected,
                  onTap: () => onTap(item),
                );
          }
```
