### PR TITLE
fix(autocomplete): prevent empty and detached popups

### DIFF
--- a/lib/src/base_dropdown_search.dart
+++ b/lib/src/base_dropdown_search.dart
@@ -348,8 +348,9 @@ class DropdownSearchState<T> extends State<BaseDropdownSearch<T>> {
   bool _handleAutoCompleteBackPressKeyPress(KeyEvent event) {
     if (event is KeyDownEvent &&
         event.logicalKey == LogicalKeyboardKey.backspace) {
-      if (_popupStateKey.currentState?.searchBoxController.text.isEmpty ==
-          true) {
+      if (getSelectedItems.isNotEmpty &&
+          _popupStateKey.currentState?.searchBoxController.text.isEmpty ==
+              true) {
         final item = getSelectedItems.last;
         removeItem(item);
         _popupStateKey.currentState?.deselectItems([item]);

--- a/lib/src/popups/autocomplete_overlay.dart
+++ b/lib/src/popups/autocomplete_overlay.dart
@@ -4,6 +4,13 @@ import 'package:dropdown_search/dropdown_search.dart';
 import 'package:dropdown_search/src/utils.dart';
 import 'package:flutter/material.dart';
 
+class OverlayPosition {
+  const OverlayPosition(this.rect, this.isDown);
+
+  final RelativeRect rect;
+  final bool isDown;
+}
+
 abstract class CustomOverlayEntry {
   OverlayEntry? overlayEntry;
   Completer? completer;
@@ -35,7 +42,7 @@ abstract class CustomOverlayEntry {
   bool isOpen() => completer?.isCompleted == false;
 
   ///return overlay position based on different params such, constrains, alignment and screen size
-  RelativeRect getOverlayPosition(
+  OverlayPosition getOverlayPosition(
       BuildContext pContext, MenuAlign? pAlign, BoxConstraints pConstraints) {
     final dropdownBox = pContext.findRenderObject() as RenderBox;
     final overlayBox =
@@ -76,7 +83,10 @@ abstract class CustomOverlayEntry {
       }
     }
 
-    return getPosition(dropdownBox, overlayBox, popupSize, lAlign);
+    return OverlayPosition(
+      getPosition(dropdownBox, overlayBox, popupSize, lAlign),
+      lAlign.isDown,
+    );
   }
 }
 
@@ -107,13 +117,13 @@ class MaterialCustomOverlyEntry extends CustomOverlayEntry {
   @override
   getOverlayEntry(BuildContext context) {
     return OverlayEntry(builder: (ctx) {
-      final pos = getOverlayPosition(context, props.align, constraints)
-          .addMargin(props.margin);
+      final position = getOverlayPosition(context, props.align, constraints);
+      final pos = position.rect.addMargin(props.margin);
       return Positioned(
-        top: pos.top,
+        top: position.isDown ? pos.top : null,
         left: pos.left,
         right: pos.right,
-        bottom: pos.bottom,
+        bottom: position.isDown ? null : pos.bottom,
         child: Container(
           constraints: constraints,
           child: TapRegion(
@@ -156,13 +166,13 @@ class CupertinoCustomOverlyEntry extends CustomOverlayEntry {
   @override
   OverlayEntry getOverlayEntry(BuildContext context) {
     return OverlayEntry(builder: (ctx) {
-      final pos = getOverlayPosition(context, props.align, constraints)
-          .addMargin(props.margin);
+      final position = getOverlayPosition(context, props.align, constraints);
+      final pos = position.rect.addMargin(props.margin);
       return Positioned(
-        top: pos.top,
+        top: position.isDown ? pos.top : null,
         left: pos.left,
         right: pos.right,
-        bottom: pos.bottom,
+        bottom: position.isDown ? null : pos.bottom,
         child: Container(
           constraints: constraints,
           child: TapRegion(

--- a/lib/src/popups/props/material_popup_props.dart
+++ b/lib/src/popups/props/material_popup_props.dart
@@ -65,7 +65,7 @@ class MultiSelectionPopupProps<T> extends BasePopupProps<T> {
   const MultiSelectionPopupProps.autocomplete({
     this.autoCompleteProps = const AutocompleteProps(),
     TextFieldProps searchFieldProps = const TextFieldProps(),
-    super.fit,
+    super.fit = FlexFit.loose,
     super.suggestionsProps,
     super.scrollbarProps,
     super.listViewProps,
@@ -272,7 +272,7 @@ class PopupProps<T> extends BasePopupProps<T> {
   const PopupProps.autocomplete({
     this.autoCompleteProps = const AutocompleteProps(),
     TextFieldProps searchFieldProps = const TextFieldProps(),
-    super.fit,
+    super.fit = FlexFit.loose,
     super.suggestionsProps,
     super.scrollbarProps,
     super.listViewProps,

--- a/lib/src/widgets/props/cupertino_popup_props.dart
+++ b/lib/src/widgets/props/cupertino_popup_props.dart
@@ -65,7 +65,7 @@ class CupertinoMultiSelectionPopupProps<T> extends BasePopupProps<T> {
   const CupertinoMultiSelectionPopupProps.autocomplete({
     this.autoCompleteProps = const CupertinoAutocompleteProps(),
     CupertinoTextFieldProps searchFieldProps = const CupertinoTextFieldProps(),
-    super.fit,
+    super.fit = FlexFit.loose,
     super.suggestionsProps,
     super.scrollbarProps,
     super.listViewProps,
@@ -264,7 +264,7 @@ class CupertinoPopupProps<T> extends BasePopupProps<T> {
   const CupertinoPopupProps.autocomplete({
     this.autoCompleteProps = const CupertinoAutocompleteProps(),
     CupertinoTextFieldProps searchFieldProps = const CupertinoTextFieldProps(),
-    super.fit,
+    super.fit = FlexFit.loose,
     super.suggestionsProps,
     super.scrollbarProps,
     super.listViewProps,


### PR DESCRIPTION
## Why

Autocomplete Backspace throws when no item is selected. A one-item autocomplete popup also expands to its maximum height and can detach from its field.

## What changed

- Guard Backspace when the selected-item list is empty.
- Size autocomplete popups to their content and anchor them using the resolved popup direction.

## Impact

Fixes Material and Cupertino autocomplete popups. No API or migration changes.

## Tests

- Static analysis passed for the overlay implementation.
- Physical-card shipping widget tests passed in the consuming app.

## Type of change

- [x] Bug fix